### PR TITLE
Add Slack online community for HN Tokyo meetup.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,7 @@ Feel free to add links with pull requests or by sending them to <antontarasenko@
 - Tokyo
   - [Meetup.com](https://www.meetup.com/Hacker-News-Tokyo-Japan/)
   - [Doorkeeper](https://hntokyo.doorkeeper.jp/)
+  - [Slack](https://hackernewstokyo.slack.com/)
   - [Facebook](https://www.facebook.com/Tokyo-Hacker-News-Community-169610256492857/)
 
 ### India


### PR DESCRIPTION
  See channel #next-hntokyo-event for next physical meetup.