### PR TITLE
HN Tokyo meetup Slack online community now has auto-invite URL.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ Feel free to add links with pull requests or by sending them to <antontarasenko@
 - Tokyo
   - [Meetup.com](https://www.meetup.com/Hacker-News-Tokyo-Japan/)
   - [Doorkeeper](https://hntokyo.doorkeeper.jp/)
-  - [Slack](https://hackernewstokyo.slack.com/)
+  - [Slack](https://hntokyo.io/)
   - [Facebook](https://www.facebook.com/Tokyo-Hacker-News-Community-169610256492857/)
 
 ### India


### PR DESCRIPTION
See Slack channel #next-hntokyo-event for next meetup after signup.