### PR TITLE
Remove ParisHackers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,6 @@ Feel free to add links with pull requests or by sending them to <antontarasenko@
 ### France
 
 - Paris
-  - [ParisHackers](http://www.meetup.com/fr-FR/ParisHackers/)
   - HN Paris
     - [Homepage](https://hn.silexlabs.org/)
     - [Meetup.com](https://www.meetup.com/Hacker-News-Paris-user-group/)


### PR DESCRIPTION
Hello! I'm the original creator of ParisHackers, which indeed started as a HN meetup that ran for a couple years. However after a job change I lost access to the meetup group, which was subsequently not renewed and taken over by some crypto people with absolutely no interest in HN. All this is quite obvious from the meetup history so it should not appear in this list anymore. thanks!