### PR TITLE
Suggest a Melbourne, AU meetup group

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ Feel free to add links with pull requests or by sending them to <antontarasenko@
 
 ### Australia
 
-- [Melbourne](https://github.com/antontarasenko/hacker-news-groups/issues/13) Interested in creating a group?  Join me :smile:
+- [Melbourne](https://lists.riseup.net/www/subscribe/hn-melbourne) Fledgling group – join me :smile:
 
 ### China
 

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,10 @@ Feel free to add links with pull requests or by sending them to <antontarasenko@
 
 ## Meetups
 
+### Australia
+
+- [Melbourne](https://github.com/antontarasenko/hacker-news-groups/issues/13) Interested in creating a group?  Join me :smile:
+
 ### China
 
 - [Shanghai](http://www.meetup.com/Shanghai-Hacker-News-Meetup/)


### PR DESCRIPTION
I'd be interested in joining, if not creating, a group in Melbourne, Australia.  The one relatively serious requirement for me, would be using no commercial community-hosting/organising site, such as Facebook (i don't have FB), or Meetup.com (i don't want to pay them), etc.

I'm looking at easy ways to have a good old-fashioned Mailman mailing list somewhere, with open archives and open subscription.

EDIT: Oh, and this closes #13.